### PR TITLE
generate ghost perk lookup table

### DIFF
--- a/generate-ghost-data.js
+++ b/generate-ghost-data.js
@@ -12,13 +12,14 @@ Object.keys(inventoryItem).forEach(function(key) {
   const description = inventoryItem[key].displayProperties.description;
   const name = inventoryItem[key].displayProperties.name;
   if (categoryHashes.includes(ghostPerkCategoryHash)) {
-    ghostPerks[hash] = {};
-    ghostPerks[hash].location = getLocation(description);
-    ghostPerks[hash].range = getRange(description);
-    ghostPerks[hash].type = getType(description);
-    ghostPerks[hash].improved = getImproved(name, description);
-    ghostPerks[hash].telemetryType = getTelemetryType(description);
-    ghostPerks[hash].boost = getBoost(description);
+    ghostPerks[hash] = {
+      location: getLocation(description),
+      range: getRange(description),
+      type: getType(description),
+      improved: getImproved(name, description),
+      telemetryType: getTelemetryType(description),
+      boost: getBoost(description)
+    };
   }
 });
 
@@ -26,27 +27,29 @@ writeFilePretty('output/ghost-perks.json', ghostPerks);
 
 function getLocation(description) {
   if (description.includes('EDZ')) {
-    return 'EDZ';
+    return 'edz';
   } else if (description.includes('Titan')) {
-    return 'Titan';
+    return 'titan';
   } else if (description.includes('Nessus')) {
-    return 'Nessus';
+    return 'nessus';
   } else if (description.includes('Io')) {
-    return 'Io';
+    return 'io';
   } else if (description.includes('Mercury')) {
-    return 'Mercury';
+    return 'mercury';
   } else if (description.includes('Hellas Basin')) {
-    return 'Mars';
+    return 'mars';
   } else if (description.includes('Tangled Shore')) {
-    return 'Tangled Shore';
+    return 'tangled';
   } else if (description.includes('Dreaming City')) {
-    return 'Dreaming City';
+    return 'dreaming';
   } else if (description.includes('Vanguard') || description.includes('Strike')) {
-    return 'Strikes';
+    return 'strikes';
   } else if (description.includes('Crucible')) {
-    return 'Crucible';
+    return 'crucible';
   } else if (description.includes('Gambit')) {
-    return 'Gambit';
+    return 'gambit';
+  } else if (description.includes('in the raids "Leviathan"')) {
+    return 'raid';
   } else {
     return false;
   }
@@ -68,22 +71,19 @@ function getRange(description) {
 
 function getType(description) {
   if (description.includes('XP')) {
-    return 'XP';
-  } else if (
-    description.includes('Detect caches or resources') ||
-    description.includes('Detects caches and resources')
-  ) {
-    return 'Combo';
+    return 'xp';
+  } else if (description.includes('caches') && description.includes('resources')) {
+    return 'combo';
   } else if (description.includes('Detect resources')) {
-    return 'Resource';
+    return 'resource';
   } else if (description.includes('Detect caches') || description.includes('Detects caches')) {
-    return 'Cache';
+    return 'cache';
   } else if (description.includes('hance to obtain additional')) {
-    return 'Scanner';
+    return 'scanner';
   } else if (description.includes('Increase Glimmer gains')) {
-    return 'Glimmer';
+    return 'glimmer';
   } else if (description.includes('Generate Gunsmith telemetry')) {
-    return 'Telemetry';
+    return 'telemetry';
   } else {
     return false;
   }
@@ -103,7 +103,6 @@ function getTelemetryType(description) {
   if (description.includes('Arc weapon kills')) {
     return 'arc';
   } else if (description.includes('Void weapon kills')) {
-    // Void weapon kills
     return 'void';
   } else if (description.includes('Solar weapon kills')) {
     return 'solar';

--- a/generate-ghost-data.js
+++ b/generate-ghost-data.js
@@ -1,0 +1,123 @@
+const { writeFilePretty, getMostRecentManifest } = require('./helpers.js');
+
+const mostRecentManifestLoaded = require(`./${getMostRecentManifest()}`);
+
+const inventoryItem = mostRecentManifestLoaded.DestinyInventoryItemDefinition;
+const ghostPerks = {};
+const ghostPerkCategoryHash = 4176831154;
+
+Object.keys(inventoryItem).forEach(function(key) {
+  const hash = inventoryItem[key].hash;
+  const categoryHashes = inventoryItem[key].itemCategoryHashes || [];
+  const description = inventoryItem[key].displayProperties.description;
+  const name = inventoryItem[key].displayProperties.name;
+  if (categoryHashes.includes(ghostPerkCategoryHash)) {
+    ghostPerks[hash] = {};
+    ghostPerks[hash].location = getLocation(description);
+    ghostPerks[hash].range = getRange(description);
+    ghostPerks[hash].type = getType(description);
+    ghostPerks[hash].improved = getImproved(name, description);
+    ghostPerks[hash].telemetryType = getTelemetryType(description);
+    ghostPerks[hash].boost = getBoost(description);
+  }
+});
+
+writeFilePretty('output/ghost-perks.json', ghostPerks);
+
+function getLocation(description) {
+  if (description.includes('EDZ')) {
+    return 'EDZ';
+  } else if (description.includes('Titan')) {
+    return 'Titan';
+  } else if (description.includes('Nessus')) {
+    return 'Nessus';
+  } else if (description.includes('Io')) {
+    return 'Io';
+  } else if (description.includes('Mercury')) {
+    return 'Mercury';
+  } else if (description.includes('Hellas Basin')) {
+    return 'Mars';
+  } else if (description.includes('Tangled Shore')) {
+    return 'Tangled Shore';
+  } else if (description.includes('Dreaming City')) {
+    return 'Dreaming City';
+  } else if (description.includes('Vanguard') || description.includes('Strike')) {
+    return 'Strikes';
+  } else if (description.includes('Crucible')) {
+    return 'Crucible';
+  } else if (description.includes('Gambit')) {
+    return 'Gambit';
+  } else {
+    return false;
+  }
+}
+
+function getRange(description) {
+  if (description.includes('30-meter range')) {
+    return 30;
+  } else if (description.includes('40-meter range')) {
+    return 40;
+  } else if (description.includes('50-meter range')) {
+    return 50;
+  } else if (description.includes('75-meter range')) {
+    return 75;
+  } else {
+    return false;
+  }
+}
+
+function getType(description) {
+  if (description.includes('XP')) {
+    return 'XP';
+  } else if (
+    description.includes('Detect caches or resources') ||
+    description.includes('Detects caches and resources')
+  ) {
+    return 'Combo';
+  } else if (description.includes('Detect resources')) {
+    return 'Resource';
+  } else if (description.includes('Detect caches') || description.includes('Detects caches')) {
+    return 'Cache';
+  } else if (description.includes('hance to obtain additional')) {
+    return 'Scanner';
+  } else if (description.includes('Increase Glimmer gains')) {
+    return 'Glimmer';
+  } else if (description.includes('Generate Gunsmith telemetry')) {
+    return 'Telemetry';
+  } else {
+    return false;
+  }
+}
+
+function getImproved(name, description) {
+  if (name.includes('Improved')) {
+    return true;
+  } else if (description.includes('at an increased rate')) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+function getTelemetryType(description) {
+  if (description.includes('Arc weapon kills')) {
+    return 'arc';
+  } else if (description.includes('Void weapon kills')) {
+    // Void weapon kills
+    return 'void';
+  } else if (description.includes('Solar weapon kills')) {
+    return 'solar';
+  } else if (description.includes('any elemental weapon kills')) {
+    return 'all';
+  } else {
+    return false;
+  }
+}
+
+function getBoost(description) {
+  if (description.includes('10%')) {
+    return 10;
+  } else {
+    return false;
+  }
+}

--- a/output/ghost-perks.json
+++ b/output/ghost-perks.json
@@ -1,0 +1,650 @@
+{
+  "30834361": {
+    "location": "Mars",
+    "range": 30,
+    "type": "Resource",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "36804749": {
+    "location": "Dreaming City",
+    "range": 30,
+    "type": "Resource",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "66383463": {
+    "location": "Nessus",
+    "range": 40,
+    "type": "Cache",
+    "improved": true,
+    "telemetryType": false,
+    "boost": false
+  },
+  "103219604": {
+    "location": false,
+    "range": false,
+    "type": "Telemetry",
+    "improved": false,
+    "telemetryType": "all",
+    "boost": false
+  },
+  "183999083": {
+    "location": "Mars",
+    "range": false,
+    "type": "Scanner",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "263169843": {
+    "location": "Titan",
+    "range": 30,
+    "type": "Resource",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "281656579": {
+    "location": "Mars",
+    "range": false,
+    "type": "Glimmer",
+    "improved": false,
+    "telemetryType": false,
+    "boost": 10
+  },
+  "322369214": {
+    "location": "Dreaming City",
+    "range": 40,
+    "type": "Cache",
+    "improved": true,
+    "telemetryType": false,
+    "boost": false
+  },
+  "329782251": {
+    "location": "Crucible",
+    "range": false,
+    "type": "XP",
+    "improved": false,
+    "telemetryType": false,
+    "boost": 10
+  },
+  "390974608": {
+    "location": "EDZ",
+    "range": 30,
+    "type": "Combo",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "478676376": {
+    "location": "Dreaming City",
+    "range": 30,
+    "type": "Combo",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "566395092": {
+    "location": "Mercury",
+    "range": false,
+    "type": "XP",
+    "improved": false,
+    "telemetryType": false,
+    "boost": 10
+  },
+  "693114386": {
+    "location": "Gambit",
+    "range": false,
+    "type": "Glimmer",
+    "improved": false,
+    "telemetryType": false,
+    "boost": 10
+  },
+  "707631447": {
+    "location": "Io",
+    "range": 30,
+    "type": "Resource",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "741416970": {
+    "location": false,
+    "range": false,
+    "type": false,
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "815624991": {
+    "location": "Titan",
+    "range": 30,
+    "type": "Combo",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "816744355": {
+    "location": "Dreaming City",
+    "range": false,
+    "type": "Glimmer",
+    "improved": false,
+    "telemetryType": false,
+    "boost": 10
+  },
+  "819844944": {
+    "location": "Mars",
+    "range": 30,
+    "type": "Combo",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "932058162": {
+    "location": "Titan",
+    "range": 30,
+    "type": "Cache",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "1048118643": {
+    "location": "Io",
+    "range": 30,
+    "type": "Combo",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "1064347710": {
+    "location": "Io",
+    "range": false,
+    "type": "XP",
+    "improved": false,
+    "telemetryType": false,
+    "boost": 10
+  },
+  "1085640235": {
+    "location": "Nessus",
+    "range": 30,
+    "type": "Resource",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "1143206163": {
+    "location": "Tangled Shore",
+    "range": 30,
+    "type": "Resource",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "1198449474": {
+    "location": "Mercury",
+    "range": false,
+    "type": "Scanner",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "1255371660": {
+    "location": "Mercury",
+    "range": 30,
+    "type": "Combo",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "1255489387": {
+    "location": false,
+    "range": false,
+    "type": "XP",
+    "improved": false,
+    "telemetryType": false,
+    "boost": 10
+  },
+  "1329583752": {
+    "location": "Crucible",
+    "range": false,
+    "type": "Scanner",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "1400394461": {
+    "location": "Titan",
+    "range": false,
+    "type": "Glimmer",
+    "improved": false,
+    "telemetryType": false,
+    "boost": 10
+  },
+  "1586768444": {
+    "location": "Mars",
+    "range": 40,
+    "type": "Cache",
+    "improved": true,
+    "telemetryType": false,
+    "boost": false
+  },
+  "1612078667": {
+    "location": false,
+    "range": false,
+    "type": false,
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "1626532497": {
+    "location": false,
+    "range": false,
+    "type": "Telemetry",
+    "improved": false,
+    "telemetryType": "arc",
+    "boost": false
+  },
+  "1702115876": {
+    "location": "Tangled Shore",
+    "range": 40,
+    "type": "Cache",
+    "improved": true,
+    "telemetryType": false,
+    "boost": false
+  },
+  "1712870644": {
+    "location": false,
+    "range": false,
+    "type": "Telemetry",
+    "improved": true,
+    "telemetryType": "all",
+    "boost": false
+  },
+  "1765741659": {
+    "location": "Io",
+    "range": 40,
+    "type": "Cache",
+    "improved": true,
+    "telemetryType": false,
+    "boost": false
+  },
+  "1791543972": {
+    "location": "Tangled Shore",
+    "range": 30,
+    "type": "Cache",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "1894263102": {
+    "location": "Nessus",
+    "range": false,
+    "type": "XP",
+    "improved": false,
+    "telemetryType": false,
+    "boost": 10
+  },
+  "1916863581": {
+    "location": "Io",
+    "range": false,
+    "type": "Glimmer",
+    "improved": false,
+    "telemetryType": false,
+    "boost": 10
+  },
+  "1933479768": {
+    "location": "Titan",
+    "range": false,
+    "type": false,
+    "improved": false,
+    "telemetryType": false,
+    "boost": 10
+  },
+  "1942048138": {
+    "location": false,
+    "range": false,
+    "type": "Telemetry",
+    "improved": false,
+    "telemetryType": "solar",
+    "boost": false
+  },
+  "1946260457": {
+    "location": "Titan",
+    "range": false,
+    "type": "Scanner",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "1990928495": {
+    "location": "EDZ",
+    "range": false,
+    "type": "XP",
+    "improved": false,
+    "telemetryType": false,
+    "boost": 10
+  },
+  "1991567150": {
+    "location": false,
+    "range": false,
+    "type": "Scanner",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "2010132761": {
+    "location": false,
+    "range": false,
+    "type": false,
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "2126415067": {
+    "location": "Mercury",
+    "range": false,
+    "type": "Glimmer",
+    "improved": false,
+    "telemetryType": false,
+    "boost": 10
+  },
+  "2142971474": {
+    "location": "Mercury",
+    "range": 40,
+    "type": "Cache",
+    "improved": true,
+    "telemetryType": false,
+    "boost": false
+  },
+  "2199055252": {
+    "location": "Io",
+    "range": 30,
+    "type": "Cache",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "2207103371": {
+    "location": false,
+    "range": false,
+    "type": "XP",
+    "improved": false,
+    "telemetryType": false,
+    "boost": 10
+  },
+  "2224144604": {
+    "location": "Mars",
+    "range": 30,
+    "type": "Cache",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "2274579115": {
+    "location": "Titan",
+    "range": 40,
+    "type": "Cache",
+    "improved": true,
+    "telemetryType": false,
+    "boost": false
+  },
+  "2328497849": {
+    "location": false,
+    "range": false,
+    "type": false,
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "2404852074": {
+    "location": "Mercury",
+    "range": 75,
+    "type": "Combo",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "2425296638": {
+    "location": "EDZ",
+    "range": false,
+    "type": "Glimmer",
+    "improved": false,
+    "telemetryType": false,
+    "boost": 10
+  },
+  "2536988426": {
+    "location": "Dreaming City",
+    "range": 30,
+    "type": "Cache",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "2595207061": {
+    "location": "Tangled Shore",
+    "range": false,
+    "type": "Glimmer",
+    "improved": false,
+    "telemetryType": false,
+    "boost": 10
+  },
+  "2602884912": {
+    "location": "Dreaming City",
+    "range": false,
+    "type": "XP",
+    "improved": false,
+    "telemetryType": false,
+    "boost": 10
+  },
+  "2645492862": {
+    "location": "EDZ",
+    "range": 40,
+    "type": "Cache",
+    "improved": true,
+    "telemetryType": false,
+    "boost": false
+  },
+  "2856116177": {
+    "location": "Nessus",
+    "range": false,
+    "type": "Glimmer",
+    "improved": false,
+    "telemetryType": false,
+    "boost": 10
+  },
+  "2858914062": {
+    "location": "Tangled Shore",
+    "range": 30,
+    "type": "Combo",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "2956832212": {
+    "location": false,
+    "range": 50,
+    "type": "Cache",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "3126446358": {
+    "location": "Tangled Shore",
+    "range": false,
+    "type": "XP",
+    "improved": false,
+    "telemetryType": false,
+    "boost": 10
+  },
+  "3138059283": {
+    "location": "Mercury",
+    "range": false,
+    "type": "Scanner",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "3147447938": {
+    "location": "EDZ",
+    "range": false,
+    "type": "Scanner",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "3249887691": {
+    "location": "Dreaming City",
+    "range": false,
+    "type": "Scanner",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "3260411014": {
+    "location": "Mercury",
+    "range": 30,
+    "type": "Cache",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "3300497782": {
+    "location": "Strikes",
+    "range": false,
+    "type": "Glimmer",
+    "improved": false,
+    "telemetryType": false,
+    "boost": 10
+  },
+  "3393447213": {
+    "location": "Nessus",
+    "range": false,
+    "type": "Scanner",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "3447587684": {
+    "location": false,
+    "range": false,
+    "type": "Telemetry",
+    "improved": true,
+    "telemetryType": "arc",
+    "boost": false
+  },
+  "3448093826": {
+    "location": false,
+    "range": false,
+    "type": "Telemetry",
+    "improved": true,
+    "telemetryType": "void",
+    "boost": false
+  },
+  "3457795268": {
+    "location": "Nessus",
+    "range": 30,
+    "type": "Cache",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "3523930524": {
+    "location": "EDZ",
+    "range": 30,
+    "type": "Resource",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "3528214957": {
+    "location": "Tangled Shore",
+    "range": false,
+    "type": "Scanner",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "3569214087": {
+    "location": "Nessus",
+    "range": 30,
+    "type": "Combo",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "3785828493": {
+    "location": false,
+    "range": false,
+    "type": false,
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "3883296839": {
+    "location": false,
+    "range": false,
+    "type": "Telemetry",
+    "improved": true,
+    "telemetryType": "solar",
+    "boost": false
+  },
+  "3900721702": {
+    "location": "Mars",
+    "range": false,
+    "type": "XP",
+    "improved": false,
+    "telemetryType": false,
+    "boost": 10
+  },
+  "3935848740": {
+    "location": "Crucible",
+    "range": false,
+    "type": "Glimmer",
+    "improved": false,
+    "telemetryType": false,
+    "boost": 10
+  },
+  "4040200521": {
+    "location": "Io",
+    "range": false,
+    "type": "Scanner",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "4051388481": {
+    "location": "EDZ",
+    "range": 30,
+    "type": "Cache",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "4082217637": {
+    "location": "Mercury",
+    "range": 30,
+    "type": "Resource",
+    "improved": false,
+    "telemetryType": false,
+    "boost": false
+  },
+  "4258605391": {
+    "location": "Gambit",
+    "range": false,
+    "type": "XP",
+    "improved": false,
+    "telemetryType": false,
+    "boost": 10
+  },
+  "4287983117": {
+    "location": false,
+    "range": false,
+    "type": "Telemetry",
+    "improved": false,
+    "telemetryType": "void",
+    "boost": false
+  }
+}


### PR DESCRIPTION
Generate ghost perk information for search

EDIT: Need to account for some of the specialized perks...
Treasure Hunter
Public Defender
Speed Demon
Scion of Mercury
Seeker of Opulence

EDIT2: Have a stash with the following schema change

```
  "30834361": {
    "location": "Mars",
    "range": 30,
    "type": {
      "xp": false,
      "resource": true,
      "cache": false,
      "scanner": false,
      "glimmer": false,
      "telemetry": {
        "arc": false,
        "void": false,
        "solar": false
      }
    },
    "improved": false,
    "boost": false
  },
```
Let me know which schema is preferred
