### PR TITLE
fine tuning source:calus

### DIFF
--- a/data/categories.json
+++ b/data/categories.json
@@ -2,7 +2,7 @@
   "sources": {
     "adventure": ["adventure"],
     "blackarmory": ["forge ignition", "glyph puzzle", "Black armory", "Obsidian Accelerator", "Reunited Siblings", "Master Blaster", "Clean Up on Aisle Five", "Beautiful but Deadly"],
-    "calus": ["leviathan", "crown of sorrow"],
+    "calus": ["leviathan raid", "Eater of Worlds raid", "Spire of Stars raid", "crown of sorrow", "menagerie.", "Menagerie aboard the Leviathan."],
     "crownofsorrow": ["crown of sorrow"],
     "crucible": ["Shaxx", "crucible"],
     "do": ["Arach Jalaal"],
@@ -57,6 +57,9 @@
       "Crown of Sorrow",
       "Imperial Opulence",
       "Shadow of Earth Shell"
+    ],
+    "leviathan":  [
+      "Legend of Acrius"
     ],
     "raid": [
       "Midnight Smith",

--- a/output/source-info.ts
+++ b/output/source-info.ts
@@ -106,6 +106,7 @@ const Sources = {
         3580904580 // Legend of Acrius
       ],
       sourceHashes: [
+        705895461, // Acquired from the Menagerie.
         1675483099, // Source: Leviathan, Spire of Stars raid lair.
         2399751101, // Acquired from the raid "Crown of Sorrow."
         2511152325, // Acquired from the Menagerie aboard the Leviathan.
@@ -115,8 +116,7 @@ const Sources = {
         2937902448, // Source: Leviathan, Eater of Worlds raid lair.
         3147603678, // Acquired from the raid "Crown of Sorrow."
         4009509410, // Source: Complete challenges in the Leviathan raid.
-        4066007318, // Source: Leviathan, Eater of Worlds raid lair on Prestige difficulty.
-        4130543671 // Acquired from the Menagerie aboard the Leviathan with the requisite combination of runes in the Chalice of Opulence.
+        4066007318 // Source: Leviathan, Eater of Worlds raid lair on Prestige difficulty.
       ]
     },
     crownofsorrow: {
@@ -247,7 +247,10 @@ const Sources = {
       ]
     },
     leviathan: {
-      itemHashes: [],
+      itemHashes: [
+        1744115122, // Legend of Acrius
+        3580904580 // Legend of Acrius
+      ],
       sourceHashes: [
         2653618435, // Source: Leviathan raid.
         2765304727, // Source: Leviathan raid on Prestige difficulty.


### PR DESCRIPTION
goes with stricter rules for `source:calus` as the generic rule was picking up the y2 exodus set, which does come from menagerie but does not count as calus-provided
opulent armor meanwhile was not picking up because the brief source string mentions menagerie but not leviathan.

also `leviathan` was missing acrius